### PR TITLE
Load embedding config from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+OLLAMA_URL=http://ollama:11434/api/embeddings
+EMBEDDING_MODEL=all-minilm:latest

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -1,7 +1,8 @@
+import os
 import requests
 
-OLLAMA_URL = "http://ollama:11434/api/embeddings"
-EMBEDDING_MODEL = "all-minilm:latest"
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://ollama:11434/api/embeddings")
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "all-minilm:latest")
 
 def ollama_embed(text: str):
     response = requests.post(OLLAMA_URL, json={"model": EMBEDDING_MODEL, "prompt": text})

--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
 from fastapi import FastAPI
+from dotenv import load_dotenv
 from app.routes.api import router
+
+load_dotenv()
 
 app = FastAPI()
 app.include_router(router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ langchain-community
 langchain-core
 langchain-ollama
 chromadb
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- read `OLLAMA_URL` and `EMBEDDING_MODEL` from environment variables
- include `python-dotenv` in requirements
- add `.env` with default settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871f2d0c37483209c0295c272a99a0c